### PR TITLE
Resolve 409 conflict on recreated branch restrictions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: [zahiar]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	@echo "In order to have Terraform pick this up you will need to add the following to your $$HOME/.terraformrc file:"
 	@echo "  provider_installation {"
 	@echo "    dev_overrides {"
-	@echo "      \"zahiar/bitbucket\" = \"$(shell go env GOPATH)/bin\""
+	@echo "      \"brnck/bitbucket\" = \"$(shell go env GOPATH)/bin\""
 	@echo "    }"
 	@echo "    direct {}"
 	@echo "  }"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ provider "bitbucket" {
 terraform {
   required_providers {
     bitbucket = {
-      source  = "zahiar/bitbucket"
+      source  = "brnck/bitbucket"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a Terraform provider for managing resources within a Bitbucket Cloud account.
 
 ## Getting Started
-As this provider is published to the public [Terraform Registry](https://registry.terraform.io/providers/zahiar/bitbucket),
+As this provider is published to the public [Terraform Registry](https://registry.terraform.io/providers/brnck/bitbucket/),
 you can install it like so (for Terraform 0.14+):
 ```hcl
 provider "bitbucket" {
@@ -20,7 +20,7 @@ terraform {
 ```
 
 For more detailed instructions and documentation on the resources and data sources supported, please go to
-[Terraform Registry](https://registry.terraform.io/providers/zahiar/bitbucket/latest/docs).
+[Terraform Registry](https://registry.terraform.io/providers/brnck/bitbucket/latest/docs).
 
 ## Maintenance
 This provider is maintained during free time, so if you are interested in helping to develop this further, you


### PR DESCRIPTION
Resolve 409 conflict on recreated branch restrictions

Update README and makefile

Context: 

When the Branch restriction is deleted and recreated manually, Terraform loses the ability to recreate the resource as Bitbucket responds **409 conflict**. 